### PR TITLE
[Meta] Remove unnecessary type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "private": true,
+	"private": true,
 	"scripts": {
 		"build": "node build.mjs"
 	},
@@ -9,17 +9,14 @@
 		"esbuild": "^0.16.14",
 		"rollup": "^3.9.1",
 		"rollup-plugin-esbuild": "^5.0.0",
-        "@react-native-clipboard/clipboard": "1.10.0",
-        "@types/react": "18.0.27",
-        "@types/react-native": "0.70.6",
-		"vendetta-types": "*"
+		"vendetta-types": "latest"
 	},
-    "pnpm": {
-        "peerDependencyRules": {
-            "ignoreMissing": [
-                "react",
-                "react-native"
-            ]
-        }
-    }
+	"pnpm": {
+		"peerDependencyRules": {
+			"ignoreMissing": [
+				"react",
+				"react-native"
+			]
+		}
+	}
 }


### PR DESCRIPTION
I wasn't able to get the inclusion of vendetta-types to work like I expected it to yesterday evening but the extra type packages are definitely not needed.